### PR TITLE
Add /gimme command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OI TLE Bot
 
-OI TLE Bot is a Discord bot designed to help competitive programmers—especially those preparing for Olympiads in Informatics (IOI, national contests, etc.)—track their progress, get practice problems, and engage in virtual contests. The bot uses the [DMOJ](https://dmoj.ca/) API to serve high-quality OI-style problems, manage user stats, and provide personalized recommendations.
+OI TLE Bot is a Discord bot designed to help competitive programmers—especially
+those preparing for Olympiads in Informatics (IOI, national contests, etc.)—track their progress, get practice problems, and engage in virtual contests. The bot uses the [DMOJ](https://dmoj.ca/) API to serve high-quality OI-style problems, manage user stats, and provide personalized recommendations.
 
 ## ✨ Features
 
@@ -9,6 +10,7 @@ OI TLE Bot is a Discord bot designed to help competitive programmers—especiall
 - 📊 Track solved problems and user performance over time
 - ⚔️ Host virtual practice contests with friends
 - 🎯 Topic-based training recommendations (e.g., DP, graphs)
+- 🎲 `/gimme` command for a random OI problem
 
 ## 🔌 Powered by
 - [DMOJ API](https://dmoj.ca/api/)
@@ -16,8 +18,18 @@ OI TLE Bot is a Discord bot designed to help competitive programmers—especiall
 - SQLite (or optional PostgreSQL) for user tracking
 
 ## 📦 Setup & Run
-> Instructions coming soon...
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set your Discord bot token as an environment variable:
+   ```bash
+   export DISCORD_TOKEN=your_bot_token
+   ```
+3. Start the bot
+   ```bash
+   python bot.py
+   ```
 
 ## 👨‍💻 Contributions
 Feel free to open issues or submit PRs to improve features, problem filters, or performance!
-

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,51 @@
+import os
+import random
+import aiohttp
+import discord
+from discord.ext import commands
+
+API_URL = 'https://dmoj.ca/api/v2/problems/'
+
+bot = commands.Bot(command_prefix='!', intents=discord.Intents.default())
+
+async def fetch_random_problem():
+    async with aiohttp.ClientSession() as session:
+        # get total number of problems
+        async with session.get(API_URL, params={'limit': 1}) as resp:
+            data = await resp.json()
+            total = data.get('meta', {}).get('total_count', 0)
+            if total == 0:
+                return 'Failed to fetch problems.'
+        # choose a random offset
+        offset = random.randint(0, total - 1)
+        async with session.get(API_URL, params={'limit': 1, 'offset': offset}) as resp:
+            data = await resp.json()
+            objs = data.get('objects') or data.get('results')
+            if not objs:
+                return 'Failed to fetch problems.'
+            prob = objs[0]
+            code = prob.get('code') or prob.get('id')
+            name = prob.get('name') or prob.get('title')
+            if code and name:
+                return f"{name} - https://dmoj.ca/problem/{code}"
+            return 'Failed to parse problem.'
+
+@bot.event
+async def on_ready():
+    print(f'Logged in as {bot.user} (ID: {bot.user.id})')
+    try:
+        await bot.tree.sync()
+    except Exception as e:
+        print(f'Failed to sync commands: {e}')
+
+@bot.tree.command(name='gimme', description='Get a random OI problem from DMOJ')
+async def gimme(interaction: discord.Interaction):
+    await interaction.response.defer()
+    text = await fetch_random_problem()
+    await interaction.followup.send(text)
+
+if __name__ == '__main__':
+    token = os.getenv('DISCORD_TOKEN')
+    if not token:
+        raise SystemExit('DISCORD_TOKEN environment variable not set')
+    bot.run(token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py>=2.0
+aiohttp


### PR DESCRIPTION
## Summary
- implement minimal Discord bot with `/gimme` command
- document usage in README
- add dependency list

## Testing
- `python -m py_compile bot.py`
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851b32eaed08324a6d2f632653e9ff5